### PR TITLE
feat: add catalog navigation

### DIFF
--- a/src/pages/catalog/ui/Catalog.tsx
+++ b/src/pages/catalog/ui/Catalog.tsx
@@ -2,13 +2,30 @@ import { useEffect, useState } from 'react';
 import { CategoriesList } from './CategoriesList/CategoriesList';
 import { FilterItem } from './FilterItem/FilterItem';
 import { client } from '../../../shared/api/clientApi/ClientApi';
-import { Category, ProductData } from '../../../shared/api/clientApi/types';
+import {
+  MainCategory,
+  ProductData,
+  Subcategory,
+} from '../../../shared/api/clientApi/types';
 import { ProductsList } from './ProductsList/ProductsList';
 import './catalog.css';
+import { SubcategoriesList } from './SubcategoriesList/SubcategoriesList';
+import {
+  emptyCategory,
+  emptySubcategory,
+} from '../../../shared/api/clientApi/constants';
+import { CatalogNavigation } from './CatalogNavigation/CatalogNavigation';
 
 export function Catalog() {
-  const [categories, setCategories] = useState<Category[]>([]);
+  const [categories, setCategories] = useState<MainCategory[]>([]);
   const [products, setProducts] = useState<ProductData[]>([]);
+  const [subcategories, setSubcategories] = useState<Subcategory[]>([
+    emptySubcategory,
+  ]);
+  const [currentCategory, setCurrentCategory] =
+    useState<MainCategory>(emptyCategory);
+  const [currentSubcategory, setCurrentSubcategory] =
+    useState<Subcategory>(emptySubcategory);
 
   async function updateProducts(): Promise<void> {
     const products = await client.getProducts();
@@ -16,9 +33,11 @@ export function Catalog() {
   }
 
   async function initial(): Promise<void> {
-    const categories = await client.getCategories();
+    await client.getMainCategories();
     const products = await client.getProducts();
-    setCategories(categories);
+    setCategories(client.categories);
+    setCurrentCategory(client.categories[0]);
+    setSubcategories(client.categories[0].subCategory);
     setProducts(products);
   }
 
@@ -28,15 +47,37 @@ export function Catalog() {
 
   return (
     <section className="catalog">
-      <div>
-        <FilterItem title="All categories">
+      <div className="filters">
+        <FilterItem title="Categories">
           <CategoriesList
             categories={categories}
-            onClick={() => updateProducts()}
+            onClick={(category) => {
+              setCurrentCategory(category);
+              setSubcategories(category.subCategory);
+              setCurrentSubcategory(emptySubcategory);
+              updateProducts();
+            }}
+          />
+        </FilterItem>
+        <FilterItem title="Subcategories">
+          <SubcategoriesList
+            subcategories={subcategories}
+            onClick={(subcategory) => {
+              setCurrentSubcategory(subcategory);
+              updateProducts();
+            }}
           />
         </FilterItem>
       </div>
-      <div>
+      <div className="products-panel">
+        <CatalogNavigation
+          category={currentCategory}
+          subcategory={currentSubcategory}
+          onClick={() => {
+            setCurrentSubcategory(emptySubcategory);
+            updateProducts();
+          }}
+        />
         <ProductsList products={products} />
       </div>
     </section>

--- a/src/pages/catalog/ui/CatalogNavigation/CatalogNavigation.css
+++ b/src/pages/catalog/ui/CatalogNavigation/CatalogNavigation.css
@@ -1,0 +1,8 @@
+.category-name:hover {
+  cursor: pointer;
+  text-decoration: underline;
+}
+
+.category-name-no-active {
+  pointer-events: none;
+}

--- a/src/pages/catalog/ui/CatalogNavigation/CatalogNavigation.tsx
+++ b/src/pages/catalog/ui/CatalogNavigation/CatalogNavigation.tsx
@@ -1,0 +1,37 @@
+import { client } from '../../../../shared/api/clientApi/ClientApi';
+import {
+  MainCategory,
+  Subcategory,
+} from '../../../../shared/api/clientApi/types';
+import './CatalogNavigation.css';
+
+type Properties = {
+  category: MainCategory;
+  subcategory: Subcategory;
+  onClick: () => void;
+};
+
+export function CatalogNavigation({
+  category,
+  subcategory,
+  onClick,
+}: Properties) {
+  const style =
+    'category-name' + (subcategory.id ? '' : 'category-name-active');
+
+  return (
+    <div>
+      <span>Main &gt; </span>
+      <span
+        className={style}
+        onClick={() => {
+          client.currentCategoryId = category.id;
+          onClick();
+        }}
+      >
+        {category.name}
+      </span>
+      {subcategory.id && <span> &gt; {subcategory.name}</span>}
+    </div>
+  );
+}

--- a/src/pages/catalog/ui/CategoriesList/CategoriesList.tsx
+++ b/src/pages/catalog/ui/CategoriesList/CategoriesList.tsx
@@ -1,46 +1,40 @@
-import { ChangeEvent, useState } from 'react';
+import { useState } from 'react';
 import { client } from '../../../../shared/api/clientApi/ClientApi';
-import { Category } from '../../../../shared/api/clientApi/types';
+import { Category, MainCategory } from '../../../../shared/api/clientApi/types';
 import './CategoriesList.css';
+import { emptyCategory } from '../../../../shared/api/clientApi/constants';
 
 type Properties = {
   categories: Category[];
-  onClick: () => void;
+  onClick: (category: MainCategory) => void;
 };
 
 export function CategoriesList({ categories, onClick }: Properties) {
-  const [selectValue, setSelectValue] = useState('');
+  if (!categories[0]) return <></>;
 
-  const handleChange = (event: ChangeEvent<HTMLInputElement>) => {
-    setSelectValue(event.target.value);
-    client.setCurrentCategoryId(event.target.value);
-    onClick();
-  };
+  // eslint-disable-next-line react-hooks/rules-of-hooks
+  const [selectValue, setSelectValue] = useState(categories[0].id);
 
   return (
     <div className="categories">
-      <div className="category-item">
-        <input
-          id="all"
-          type="radio"
-          name="category"
-          value=""
-          checked={selectValue === ''}
-          onChange={handleChange}
-        />
-        <label htmlFor="all">All</label>
-      </div>
-      {categories.map((s) => (
-        <div key={s.id} className="category-item">
+      {categories.map((category) => (
+        <div key={category.id} className="category-item">
           <input
-            id={s.id}
             type="radio"
             name="category"
-            value={s.id}
-            checked={selectValue === s.id}
-            onChange={handleChange}
+            id={category.id}
+            value={category.id}
+            checked={selectValue === category.id}
+            onChange={(event) => {
+              setSelectValue(event.target.value);
+              client.currentCategoryId = event.target.value;
+              const currentCategory = client.categories.find(
+                (item) => item.id === category.id
+              );
+              onClick(currentCategory || emptyCategory);
+            }}
           />
-          <label htmlFor={s.id}>{s.name}</label>
+          <label htmlFor={category.id}>{category.name}</label>
         </div>
       ))}
     </div>

--- a/src/pages/catalog/ui/SubcategoriesList/SubcategoriesList.css
+++ b/src/pages/catalog/ui/SubcategoriesList/SubcategoriesList.css
@@ -1,0 +1,14 @@
+.categories {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.subcategory-item {
+  display: flex;
+  gap: 0.5rem;
+}
+
+.subcategory-item label {
+  width: 100%;
+}

--- a/src/pages/catalog/ui/SubcategoriesList/SubcategoriesList.tsx
+++ b/src/pages/catalog/ui/SubcategoriesList/SubcategoriesList.tsx
@@ -1,0 +1,38 @@
+import { useState } from 'react';
+import { client } from '../../../../shared/api/clientApi/ClientApi';
+import { Category, Subcategory } from '../../../../shared/api/clientApi/types';
+import './SubcategoriesList.css';
+
+type CategoriesListProperties = {
+  subcategories: Category[];
+  onClick: (subcategory: Subcategory) => void;
+};
+
+export function SubcategoriesList({
+  subcategories,
+  onClick,
+}: CategoriesListProperties) {
+  const [selectValue, setSelectValue] = useState(subcategories[0].id);
+
+  return (
+    <div className="categories">
+      {subcategories.map((subcategory) => (
+        <div key={subcategory.id} className="subcategory-item">
+          <input
+            type="radio"
+            name="subcategory"
+            id={subcategory.id}
+            value={subcategory.id}
+            checked={selectValue === subcategory.id}
+            onChange={(event) => {
+              setSelectValue(event.target.value);
+              client.currentCategoryId = subcategory.id;
+              onClick(subcategory);
+            }}
+          />
+          <label htmlFor={subcategory.id}>{subcategory.name}</label>
+        </div>
+      ))}
+    </div>
+  );
+}

--- a/src/pages/catalog/ui/catalog.css
+++ b/src/pages/catalog/ui/catalog.css
@@ -6,3 +6,15 @@
   max-width: 1440px;
   margin-bottom: auto;
 }
+
+.filters {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.products-panel {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}

--- a/src/shared/api/clientApi/ClientApi.ts
+++ b/src/shared/api/clientApi/ClientApi.ts
@@ -10,15 +10,16 @@ import {
   CreateAnonymousApiRoot,
   CreatePasswordApiRoot,
 } from './CreateApiRoots';
-import type { Category, loginDTO, ProductData, singUpDTO } from './types';
+import type { loginDTO, MainCategory, ProductData, singUpDTO } from './types';
 import { parseProduct } from './parseProduct';
 import { emptyProduct } from './constants';
+import { parseCategories } from './parseCategories';
 
 class ClientApi {
   public isLogin: boolean;
+  public categories: MainCategory[];
+  public currentCategoryId: string;
   private apiRoot: ByProjectKeyRequestBuilder;
-  private currentCategoryId: string;
-  private categories: Category[];
 
   constructor() {
     this.isLogin = false;
@@ -104,23 +105,6 @@ class ClientApi {
     return result;
   }
 
-  public async getCategories(): Promise<Category[]> {
-    try {
-      const response = await this.apiRoot.categories().get().execute();
-      this.categories = response.body.results.map((s) => ({
-        id: s.id,
-        name: s.name['en-US'],
-      }));
-      return this.categories;
-    } catch {
-      return [];
-    }
-  }
-
-  public setCurrentCategoryId(id: string): void {
-    this.currentCategoryId = id;
-  }
-
   public getCategoryName(id: string): string {
     const category = this.categories.find((item) => item.id === id);
     if (category) return category.name;
@@ -163,6 +147,16 @@ class ClientApi {
       return parseProduct(result);
     } catch {
       return emptyProduct;
+    }
+  }
+
+  public async getMainCategories(): Promise<void> {
+    try {
+      const response = await this.apiRoot.categories().get().execute();
+      this.categories = parseCategories(response.body.results);
+      this.currentCategoryId = this.categories[0].id;
+    } catch {
+      this.categories = [];
     }
   }
 }

--- a/src/shared/api/clientApi/constants.ts
+++ b/src/shared/api/clientApi/constants.ts
@@ -1,4 +1,6 @@
-export const emptyProduct = {
+import { MainCategory, ProductData, Subcategory } from './types';
+
+export const emptyProduct: ProductData = {
   id: '',
   title: '',
   images: [],
@@ -7,4 +9,15 @@ export const emptyProduct = {
   price: 0,
   discountedPrice: 0,
   categoryName: '',
+};
+
+export const emptySubcategory: Subcategory = {
+  id: '',
+  name: '',
+};
+
+export const emptyCategory: MainCategory = {
+  id: '',
+  name: '',
+  subCategory: [],
 };

--- a/src/shared/api/clientApi/parseCategories.ts
+++ b/src/shared/api/clientApi/parseCategories.ts
@@ -1,0 +1,21 @@
+import type { Category } from '@commercetools/platform-sdk';
+import type { MainCategory } from './types';
+
+export function parseCategories(categories: Category[]): MainCategory[] {
+  const mainCategories: Category[] = categories.filter(
+    (category) => !category.parent
+  );
+  return mainCategories.map((category) => ({
+    id: category.id,
+    name: category.name['en-US'],
+    subCategory: categories
+      .filter(
+        (subcategory) =>
+          subcategory.parent && subcategory.parent.id === category.id
+      )
+      .map((subcategory) => ({
+        id: subcategory.id,
+        name: subcategory.name['en-US'],
+      })),
+  }));
+}

--- a/src/shared/api/clientApi/types.ts
+++ b/src/shared/api/clientApi/types.ts
@@ -29,3 +29,14 @@ export type AttributesData = {
   descriptionShort: string;
   descriptionFull: string;
 };
+
+export type Subcategory = {
+  id: string;
+  name: string;
+};
+
+export type MainCategory = {
+  id: string;
+  name: string;
+  subCategory: Subcategory[];
+};


### PR DESCRIPTION
#### 🤔 This is a ...

- [x] New feature
- [ ] Bug fix
- [ ] Performance optimization
- [ ] Refactoring
- [ ] Test Case
- [ ] Documentation update
- [ ] Other

#### 🔗 Related issue link

Implement easy-to-use and clear navigation options for users to explore and switch between different product categories or subcategories using the commercetools API. [RSS-ECOMM-3_08](https://github.com/rolling-scopes-school/tasks/blob/master/tasks/eCommerce-Application/Sprints/Sprint3/RSS-ECOMM-3_08.md)

#### 💡 Background and solution

Add catalog navigation

#### ☑️ Self Check before Merge

⚠️ Please check all items below before review. ⚠️

- [ ] Database migration is added or not needed
- [ ] Documentation is updated/provided or not needed
- [ ] Changes are tested locally
