### PR TITLE
fix: add setAddresses to address form

### DIFF
--- a/src/pages/profile/ui/components/AccountAddressForm.tsx
+++ b/src/pages/profile/ui/components/AccountAddressForm.tsx
@@ -36,6 +36,7 @@ export function AccountAddressForm(properties: AccountAddressFormProperties) {
     if (id) {
       client.updateAddress(id, data).then((addresses) => {
         closeModal?.();
+        console.log(setAddresses);
         setAddresses?.([...(addresses || [])]);
       });
     } else {

--- a/src/pages/profile/ui/components/AccountAddresses.tsx
+++ b/src/pages/profile/ui/components/AccountAddresses.tsx
@@ -1,22 +1,11 @@
 import { useState } from 'react';
 import { Button } from '../../../../shared/ui/Button';
 import { Modal } from '../../../../shared/ui/Modal';
-import {
-  MOCK_DEFAULT_ADDRESS,
-  // MOCK_DEFAULT_BILLING_ADDRESS,
-  // MOCK_DEFAULT_SHIPPING_ADDRESS,
-} from '../../model/DefaultAddresses';
-// import { AccountAddressFormData } from '../../types/types';
+import { MOCK_DEFAULT_ADDRESS } from '../../model/DefaultAddresses';
 import { AccountAddressForm } from './AccountAddressForm';
 import { client } from '../../../../shared/api/clientApi/ClientApi';
 
 export function AccountAddresses() {
-  // const getAddresses: AccountAddressFormData[] = [
-  //   MOCK_DEFAULT_SHIPPING_ADDRESS,
-  //   MOCK_DEFAULT_BILLING_ADDRESS,
-  // ];
-
-  // const [addresses, setAddresses] = useState(getAddresses);
   const [addresses, setAddresses] = useState(
     client.profileData.accountAddresses
   );
@@ -43,6 +32,7 @@ export function AccountAddresses() {
                 defaultForBilling: address.defaultForBilling,
               }}
               isShowInModal={false}
+              setAddresses={setAddresses}
             />
           );
         })}
@@ -60,6 +50,12 @@ export function AccountAddresses() {
             setAddresses={setAddresses}
           ></AccountAddressForm>
         </Modal>
+      )}
+
+      {addresses.length === 0 && (
+        <p>
+          <strong>No addresses</strong>
+        </p>
       )}
 
       <Button type="button" onClick={openModalHandler}>


### PR DESCRIPTION
#### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Performance optimization
- [ ] Refactoring
- [ ] Test Case
- [ ] Documentation update
- [ ] Other

#### 🔗 Related issue link

Allow users to manage their addresses, including adding new addresses, deleting existing ones, and updating address details. [RSS-ECOMM-3_18](https://github.com/rolling-scopes-school/tasks/blob/master/tasks/eCommerce-Application/Sprints/Sprint3/RSS-ECOMM-3_18.md)

#### 💡 Background and solution

Add setAddressess to address form for rendering

#### ☑️ Self Check before Merge

⚠️ Please check all items below before review. ⚠️

- [ ] Database migration is added or not needed
- [ ] Documentation is updated/provided or not needed
- [ ] Changes are tested locally
